### PR TITLE
test: Добавление юнит-тестов для схем, сервиса моделей и препроцессинга

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/unit/schemas/test_response.py
+++ b/tests/unit/schemas/test_response.py
@@ -1,0 +1,49 @@
+"""
+Модуль tests.unit.schemas.test_response
+Тесты для Pydantic-моделей SearchItem и SearchResponse.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas.response import SearchItem, SearchResponse
+
+
+def test_search_item_valid():
+    """
+    Проверяем, что SearchItem корректно валидируется для правильных типов.
+    """
+    item = SearchItem(path="img.jpg", class_name="Whale", distance=0.123)
+    assert item.path == "img.jpg"
+    assert item.class_name == "Whale"
+    assert isinstance(item.distance, float)
+
+
+def test_search_item_invalid_types():
+    """
+    Проверяем, что ValidationError возникает при некорректных типах полей.
+    """
+    with pytest.raises(ValidationError):
+        SearchItem(path=123, class_name="Whale", distance=0.123)
+    with pytest.raises(ValidationError):
+        SearchItem(path="img.jpg", class_name=456, distance=0.123)
+    with pytest.raises(ValidationError):
+        SearchItem(path="img.jpg", class_name="Whale", distance="bad")
+
+
+def test_search_response_valid_list():
+    """
+    Проверяем, что SearchResponse принимает список моделей SearchItem.
+    """
+    item = SearchItem(path="img.jpg", class_name="W", distance=1.0)
+    resp = SearchResponse(results=[item])
+    assert isinstance(resp.results, list)
+    assert isinstance(resp.results[0], SearchItem)
+
+
+def test_search_response_invalid_list_type():
+    """
+    Проверяем, что ValidationError возникает при передаче не списка в results.
+    """
+    with pytest.raises(ValidationError):
+        SearchResponse(results="not a list")

--- a/tests/unit/services/test_model_service.py
+++ b/tests/unit/services/test_model_service.py
@@ -1,0 +1,139 @@
+"""
+Модуль tests.unit.services.test_model_service
+
+Тесты для класса ModelService:
+    - загрузка базовой модели из конфига
+    - preprocess_and_embed корректно вызывает preprocess_image и возвращает
+    numpy.ndarray
+    - search возвращает топ-K результатов из FAISS-индекса
+"""
+
+import json
+
+import faiss
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+import yaml
+
+from backend.services.model_service import ModelService
+
+
+@pytest.fixture
+def config_and_index(tmp_path, monkeypatch):
+    """
+    Фикстура для создания временного конфига, весов модели и FAISS-индекса.
+
+    Возвращает:
+        Tuple[Path, int]: путь к config.yaml и размерность эмбеддинга.
+    """
+    base_dim = 4
+
+    class DummyModel(nn.Module):
+        """
+        Простая линейная модель для тестирования загрузки.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.layer = nn.Linear(base_dim, base_dim)
+
+        def forward(self, x):
+            """
+            Прямой проход входного тензора через линейный слой.
+            """
+            return self.layer(x)
+
+    # сохраняем state_dict DummyModel
+    weights_path = tmp_path / "weights.pth"
+    dummy = DummyModel()
+    torch.save(dummy.state_dict(), weights_path)
+
+    # подменяем timm.create_model и torch.load
+    monkeypatch.setattr(
+        "timm.create_model", lambda name, pretrained: DummyModel()
+    )
+    monkeypatch.setattr(
+        "torch.load", lambda path, map_location=None: dummy.state_dict()
+    )
+
+    # пишем конфиг YAML
+    cfg = {
+        "load_model": {
+            "compress_model": False,
+            "model_name": "dummy",
+            "compressed_shape": base_dim,
+            "weights_path": str(weights_path),
+        },
+        "index": {"prefix": str(tmp_path / "test_index")},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(cfg))
+
+    # создаём FAISS-индекс и метаданные
+    embeddings = np.eye(base_dim, dtype="float32")
+    index = faiss.IndexFlatL2(base_dim)
+    index.add(embeddings)
+    idx_file = tmp_path / "test_index.index"
+    faiss.write_index(index, str(idx_file))
+
+    meta = {
+        "paths": [f"p{i}" for i in range(base_dim)],
+        "class_names": [f"c{i}" for i in range(base_dim)],
+    }
+    meta_path = tmp_path / "test_index.json"
+    meta_path.write_text(json.dumps(meta))
+
+    return config_path, base_dim
+
+
+def test_preprocess_and_embed(monkeypatch, config_and_index):
+    """
+    Проверяет, что preprocess_and_embed возвращает numpy.ndarray
+    правильной формы.
+    Мы мокируем preprocess_image и затем переназначаем svc.model,
+    чтобы не было несоответствия форм.
+    """
+    config_path, base_dim = config_and_index
+
+    # Подменяем функцию preprocess_image на выдачу тензора (1, base_dim)
+    fake_tensor = torch.zeros(1, base_dim)
+    monkeypatch.setattr(
+        "backend.services.model_service.preprocess_image",
+        lambda f: fake_tensor,
+    )
+
+    svc = ModelService(config_path)
+    # Переназначаем модель: на вход берёт любой тензор,
+    # возвращает fake_tensor
+    svc.model = lambda x: fake_tensor
+
+    emb = svc.preprocess_and_embed(None)
+
+    assert isinstance(emb, np.ndarray), "Ожидается numpy.ndarray"
+    assert emb.shape == (
+        1,
+        base_dim,
+    ), f"Неверная форма эмбеддинга: {emb.shape}"
+
+
+def test_search_returns_top_k(config_and_index):
+    """
+    Проверяет, что метод search возвращает корректный топ-K результатов.
+    Используем нулевой запрос, чтобы ближайшим оказался индекс 0.
+    """
+    config_path, base_dim = config_and_index
+    svc = ModelService(config_path)
+
+    query = np.zeros((1, base_dim), dtype="float32")
+    k = 3
+    results = svc.search(query, k)
+
+    assert isinstance(results, list)
+    assert len(results) == k
+
+    for i, item in enumerate(results):
+        assert item["path"] == f"p{i}"
+        assert item["class_name"] == f"c{i}"
+        assert isinstance(item["distance"], float)

--- a/tests/unit/utils/test_preprocess.py
+++ b/tests/unit/utils/test_preprocess.py
@@ -1,0 +1,56 @@
+"""
+Модуль test_preprocess
+Тесты для функции preprocess_image из backend/utils/preprocess.py.
+Проверяет правильность преобразования изображения в torch.Tensor.
+"""
+
+from io import BytesIO
+
+import torch
+from PIL import Image
+
+from backend.utils.preprocess import preprocess_image
+
+
+def create_test_image(color=(123, 222, 64), size=(224, 224)):
+    """
+    Создаёт изображение указанного цвета и размера и возвращает его как
+    BytesIO.
+    """
+    img = Image.new("RGB", size, color)
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    buf.seek(0)
+    return buf
+
+
+def test_preprocess_image_returns_tensor():
+    """
+    Проверяем, что preprocess_image возвращает torch.Tensor
+    с формой (1, 3, 224, 224) и значениями в диапазоне [0, 1].
+    """
+    buf = create_test_image()
+    tensor = preprocess_image(buf)
+    assert isinstance(tensor, torch.Tensor), "Ожидается объект torch.Tensor"
+    assert tensor.shape == (
+        1,
+        3,
+        224,
+        224,
+    ), f"Неправильная форма тензора: {tensor.shape}"
+    assert torch.all(tensor >= 0) and torch.all(
+        tensor <= 1
+    ), "Значения тензора должны быть в [0,1]"
+
+
+def test_preprocess_image_resizes_correctly():
+    """
+    Проверяем, что функция ресайзит изображение к размерам 224×224.
+    Для этого передаём картинку другого размера и проверяем форму.
+    """
+    buf = create_test_image(size=(300, 150))
+    tensor = preprocess_image(buf)
+    assert tensor.shape[2:] == (
+        224,
+        224,
+    ), f"Изображение не было ресайзнуто: {tensor.shape[2:]}"


### PR DESCRIPTION
### Добавлены юнит-тесты для:

1. Валидации схем ответа (SearchItem/SearchResponse)

2. Работы ModelService (загрузка моделей, препроцессинг, поиск)

3. Преобразования изображений в тензоры

Тесты используют pytest, мокирование зависимостей и временные файлы. Покрывают ключевые сценарии работы компонентов.

#### 1. Тесты для Pydantic-схем (tests/unit/schemas/test_response.py)
1. Проверка валидации корректных данных
2. Контроль обработки невалидных входных данных
3. Валидация коллекций результатов

#### 2. Тесты для сервиса моделей (tests/unit/services/test_model_service.py)
1. Фикстура для изолированного тестирования
2. Тест препроцессинга и эмбеддинга
3. Тест поиска в FAISS-индексе

#### 3. Тесты для препроцессинга изображений
1. Генерация тестовых изображений
2. Валидация преобразования в тензор
3. Контроль ресайзинга